### PR TITLE
Fix/backspace in cursor pos

### DIFF
--- a/src/JS/cursor.js
+++ b/src/JS/cursor.js
@@ -101,12 +101,10 @@ class Cursor {
         this.create_cursor(element_parent);
 
         if (pos == "before"){
-            element_parent.insertBefore(cursor_element, element);
-            console.log("atrás");
+            element_parent.insertBefore(this.cursor_element, element);
         }
         if (pos == "after"){
-            element.after(cursor_element);
-            console.log("frente");
+            element.after(this.cursor_element);
         }
     }
 

--- a/src/JS/writing.js
+++ b/src/JS/writing.js
@@ -19,13 +19,15 @@ class WriteEquation {
     
     write_key(kb_event) {
         if (this.cursor.cursor_exist){
+
             if(kb_event.code == "Backspace"){
-                let cursor_parent = this.cursor.cursor_element.parentElement;
-                if (cursor_parent.childNodes.length > 1){
-                    let penult_pos = cursor_parent.childNodes.length - 2;
-                    cursor_parent.childNodes[penult_pos].remove();
+                let element_to_remove = this.cursor.cursor_element.previousSibling;
+
+                if(element_to_remove){
+                    element_to_remove.remove();
                 }
             }
+
             if(this.writeble_codes.includes(kb_event.code)){
                 let new_char_element = document.createElement("var");
                 new_char_element.innerText = kb_event.key;


### PR DESCRIPTION
Antes quando vc clicava em backspace sempre o ultimo caractere era excluido, agora apenas o caractere antes do cursor é deletado

## Modificação HotFix inesperada
- Dentro do arquivo cursor.js um atributo da classe estava sem o this, isso ocorreu na ultima PR cursor_moving, entretanto essa PR já resolve esse pequeno problema